### PR TITLE
YUIDOC - narzędzie do generowania dokumentacji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # binaries dir
 /bin
 
+#documentation
+/docs
+
 # logs
 *.log
 .idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,12 +26,27 @@ module.exports = function(grunt) {
                 dest: 'bin/',
                 ext: '.js'
             }
+        },
+        yuidoc: {
+            all: {
+                name: "io-2014-docs",
+                description: "volunteer computing documentation",
+                version: "0.2.1",
+                options: {
+                    linkNatives: 'true',
+                    paths: ['./src/'],
+                    outdir: './docs/',
+                    syntaxtype: 'coffee',
+                    extension: '.coffee'
+                },
+            }
         }
     });
 
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-coffee');
+    grunt.loadNpmTasks('grunt-contrib-yuidoc');
 
-    grunt.registerTask('default', ['clean:bin', 'copy', 'coffee', 'clean:coffee']);
+    grunt.registerTask('default', ['clean:bin', 'copy', 'coffee', 'clean:coffee', 'yuidoc']);
 };

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "jasmine-node": "2.0",
     "coffee-script": "1.7.x",
     "grunt": "0.4.x",
+    "yuidocjs": "0.3.x",
     "grunt-contrib-coffee": "0.10.x",
     "grunt-contrib-clean": "0.5.x",
-    "grunt-contrib-copy": "0.5.x"
+    "grunt-contrib-copy": "0.5.x",
+    "grunt-contrib-yuidoc": "0.3.x"
   },
   "directories": {
     "src": "./src",

--- a/src/js_injector.coffee
+++ b/src/js_injector.coffee
@@ -1,3 +1,8 @@
+###*
+# js_injector class.
+# @class js_injector
+###
+
 class JsInjector
   constructor: (@connectionManager) ->
 


### PR DESCRIPTION
Yuidoc generuje dokumentację na podstawie komentarzy w kodzie - coś jak doxygen. Obecnie działa on dla plików z rozszerzeniem .coffee (można ustawić js lub coffee - nie da się obydwu, patrzyłem w ich repo czy jest może taka funkcjonalność - jest ale jako pull request i nie wiadomo kiedy to zmergują). Tworzy się folder docs/ w głównym folderze projektu i tam są pliki dokumentacji, m.in. index.html. Na wiki wrzucę stronę jak komentować itp itd jakby ktoś miał problem. Oraz napiszę jak się komentuje bloki w cs - inaczej niż w js.
