### PR TITLE
Komunikacja ResultAggregator -> AdminConsole w celu notyfikowania o postępie

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "scripts": {
         "prestart": "node -e \"require('grunt').cli();\"",
         "start": "node ./bin/server.js",
-        "test": "jasmine-node --coffee ./spec/",
+        "test": "jasmine-node --verbose --coffee ./spec/",
         "selenium": "start-selenium",
         "accept": "jasmine-node --captureExceptions --coffee ./acceptance_test/"
     }

--- a/src/admin_console.coffee
+++ b/src/admin_console.coffee
@@ -40,6 +40,15 @@ class AdminConsole
     ###
     @taskManager = new TaskManager(@dispatcher, @jsInjector, @resultAgregator)
 
+    @resultAgregator.on 'partialResultReady', (taskId, readyJobIdsCount) =>
+      allJobIdsCount = Object.keys(@dispatcher.getJobs(taskId)).length
+      percentage = readyJobIdsCount * 100 / allJobIdsCount
+      if percentage >= 100
+        result = @resultAgregator.getCurrentResult(taskId).mergedResult
+        @notifyResult taskId, result
+      else
+        @notifyProgress taskId, parseInt percentage
+
     @sockets.on 'connection', (socket) =>
       console.log 'admin connected'
       socket.on 'command', (data) =>

--- a/src/public_scripts/admin.coffee
+++ b/src/public_scripts/admin.coffee
@@ -148,7 +148,10 @@ class Admin
     taskId = payload.taskId
     result = payload.result
     taskResult = @taskResultPrefix + taskId + @taskResultInfix + result + @taskResultPostfix
-    $("#progressBar_" + taskId).replaceWith(taskResult)
+    try
+      $("#progressBar_" + taskId).replaceWith(taskResult)
+    catch error
+      console.log "No progress bar for given taskId"
 
   ###*
   # Handler called when task progress needs to be updated
@@ -158,7 +161,10 @@ class Admin
   onProgress: (payload) ->
     taskId = payload.taskId
     progress = payload.progress
-    @increaseProgress($("#progressBar_" + taskId)[0], progress)
+    try
+      @increaseProgress($("#progressBar_" + taskId)[0], progress)
+    catch error
+      console.log "No progress bar for given taskId"
 
 admin = new Admin()
 

--- a/src/result_aggregator.coffee
+++ b/src/result_aggregator.coffee
@@ -5,7 +5,7 @@ events = require('events');
 # @class ResultAggregator
 # @constructor  
 ###
-class ResultAggregator
+class ResultAggregator extends events.EventEmitter
 
   constructor: (@connectionManager) ->
     events.EventEmitter.call this
@@ -13,6 +13,7 @@ class ResultAggregator
 
     @connectionManager.on 'resultReady', (socket, payload) =>
       @addResultFor(payload.taskId, payload.jobId, payload.jobResult)
+      @onPartialResult payload.taskId
 
   ###*
   # Forget specific task
@@ -42,6 +43,15 @@ class ResultAggregator
     if @results[taskId]
       partialResults: @results[taskId].partialResults,
       mergedResult: @results[taskId].taskMergeFun(result for jobId, result of @results[taskId].partialResults)
+
+  ###*
+  # Emits event containing information about given task update
+  # and number of jobs already computed
+  # @method onPartialResult
+  # @param {Integer} taskId identifier of the task
+  ###
+  onPartialResult: (taskId) ->
+    @emit 'partialResultReady', taskId, Object.keys(@results[taskId].partialResults).length
 
   ###*
   # Aggregates result for given job in given task


### PR DESCRIPTION
Resolves #87 
Z moich analiz kodu wynika, że tak to będzie wyglądało:
- ResultAggregator dostaje event 'resultReady', który reemituje wraz z liczbą policzonych już jobów
- AdminConsole dostaje powyższy event, pyta JobDispatchera o to ile wszystkich jobów przydzielił na task
- AdminConsole wysyła notyfikację dla admina z rezultatem bądź wartością określającą postęp w procentach
